### PR TITLE
fix(ci): allow headless login on mfa / passkey-gated orgs

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -39,6 +39,31 @@ exports.config = {
   ],
   before: async function () {
     await browser.setWindowSize(1920, 1080);
+    // Register a verified virtual WebAuthn authenticator for the session.
+    // Orgs that enforce MFA / passkey (WebAuthn) — e.g. a required passkey
+    // enrollment or identity verification on unrecognized devices — otherwise
+    // trap the headless browser on the "Create a Passkey" screen, so the login
+    // never reaches Lightning ("Did not reach a Lightning page"). A headless CI
+    // browser has no real authenticator and that screen has no skip option, and
+    // trusted IP ranges don't help (a passkey is a device-bound credential, not
+    // an IP challenge). With a verified virtual platform authenticator present,
+    // Salesforce satisfies the ceremony automatically and the login proceeds —
+    // no org change required. (W3C WebAuthn virtual authenticator, supported by
+    // chromedriver.)
+    try {
+      await browser.addVirtualAuthenticator(
+        'ctap2',
+        'internal',
+        true, // hasResidentKey
+        true, // hasUserVerification
+        true, // isUserConsenting
+        true // isUserVerified
+      );
+    } catch (error) {
+      // older drivers / non-Chromium browsers may not support this; suites that
+      // run against orgs without a passkey requirement are unaffected
+      console.log(`Virtual authenticator not registered: ${error.message}`);
+    }
   },
   framework: 'jasmine',
   reporters: ['spec'],


### PR DESCRIPTION
## Problem

On orgs that enforce MFA / passkey (WebAuthn) — a required passkey enrollment or identity verification on unrecognized devices — **every UI test fails at login** with `Did not reach a Lightning page`. The frontdoor login lands on the "Create a Passkey" screen (`/_ui/identity/webauthn/Add`) and never proceeds to Lightning.

This is unavoidable from the test side:

- a headless CI browser has **no real authenticator**,
- the screen offers **no skip** option, and
- **trusted IP ranges don't help** — a passkey is a *device-bound* WebAuthn credential, not an IP challenge.

The result is that the whole suite becomes unrunnable against such orgs (and, combined with retry/session-recovery, a total login block can amplify into multi-hour runs).

## Fix

Register a **verified virtual platform WebAuthn authenticator** in the wdio `before` hook (W3C WebAuthn virtual authenticator, supported by chromedriver). With a verified authenticator present, Salesforce satisfies the ceremony automatically and the login proceeds straight to Lightning — **no org-side change required**.

```js
await browser.addVirtualAuthenticator('ctap2', 'internal', true, true, true, true);
```

Wrapped in `try/catch`, so drivers/browsers without support — and orgs that don't force passkeys — are unaffected (no-op).

## Verification

- Frontdoor login check: passes in ~10s (previously blocked on the passkey screen).
- Full UI test (login + record interaction): green.

Single-file change in `wdio.conf.js`.


